### PR TITLE
Fix BLE logic errors

### DIFF
--- a/app/routes/Home.tsx
+++ b/app/routes/Home.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   ScrollView,
   RefreshControl,
   StyleSheet,
   Text,
   View,
+  Vibration,
 } from "react-native";
 import { useBle } from "../Contexts/BleContext";
 import {
@@ -37,6 +38,16 @@ export default function Home() {
     progress = Math.max(0, Math.min(1, progress));
     return progress;
   };
+
+  useEffect(() => {
+    if (rssi !== null) {
+      const progress = getProgressFromRSSI(rssi);
+      console.log("progress -> ", progress);
+      if (progress <= 0.3) {
+        Vibration.vibrate(1000);
+      }
+    }
+  }, [rssi]);
 
   const onRefresh = async () => {
     setRefreshing(true);
@@ -98,6 +109,7 @@ export default function Home() {
                   : "Muito distante"}
               </Text>
             </View>
+            <Text style={{ marginTop: 12 }}>Potencia do sinal: {rssi}</Text>
           </Card.Content>
         </Card>
       )}

--- a/app/routes/Settings.tsx
+++ b/app/routes/Settings.tsx
@@ -55,9 +55,11 @@ export default function Settings() {
 
   const handleConnect = async (id: string) => {
     try {
-      await connectToDevice(id);
-      setDevicesList([]);
-      listenNotifications(connectedDevice!); // escuta após conectar
+      const device = await connectToDevice(id);
+      if (device) {
+        setDevicesList([]);
+        listenNotifications(device); // escuta após conectar
+      }
     } catch (error) {
       console.error("Erro ao conectar:", error);
     }


### PR DESCRIPTION
## Summary
- return the connected device when connecting via BLE
- simplify Bluetooth power status check
- use returned device when opening notifications in settings

## Testing
- `npx tsc -p tsconfig.json`
- `npm test`
- `npm run lint` *(fails: EnvHttpProxyAgent is experimental, fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_685a0bb717a08324b1c4aa71b37cc3fe