### PR TITLE
Add notification when BLE receives message

### DIFF
--- a/app/routes/Settings.tsx
+++ b/app/routes/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Text,
   View,
@@ -6,11 +6,13 @@ import {
   FlatList,
   Alert,
   ActivityIndicator,
+  Vibration,
 } from "react-native";
 import { Device } from "react-native-ble-plx";
 import { Buffer } from "buffer";
 import { useBle } from "../Contexts/BleContext";
 import { BleManager } from "react-native-ble-plx";
+import * as Notifications from "expo-notifications";
 
 export default function Settings() {
   const { connectedDevice, isConnected, connectToDevice, disconnectDevice } =
@@ -21,6 +23,10 @@ export default function Settings() {
   >([]);
   const [isLoading, setIsLoading] = useState(false);
   const [receivedMessage, setReceivedMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    Notifications.requestPermissionsAsync();
+  }, []);
 
   const SERVICE_UUID = "4fafc201-1fb5-459e-8fcc-c5c9c331914b";
   const CHARACTERISTIC_UUID = "beb5483e-36e1-4688-b7f5-ea07361b26a8";
@@ -80,6 +86,12 @@ export default function Settings() {
           );
           console.log("Recebido do ESP32:", decoded);
           setReceivedMessage(decoded);
+          Alert.alert("Mensagem recebida", decoded);
+          Vibration.vibrate(1000);
+          Notifications.scheduleNotificationAsync({
+            content: { title: "Mensagem recebida", body: decoded, sound: true },
+            trigger: null,
+          });
         }
       }
     );

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "expo-font": "~13.0.4",
     "expo-haptics": "~14.0.1",
     "expo-linking": "~7.0.5",
+    "expo-notifications": "~0.29.13",
     "expo-router": "~4.0.17",
     "expo-splash-screen": "~0.29.22",
     "expo-status-bar": "~2.0.1",


### PR DESCRIPTION
## Summary
- add `expo-notifications` dependency
- vibrate and play an alert when a BLE message arrives

## Testing
- `npm test`
- `npm run lint` *(fails: fetch failed because environment has no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685a1cdda5748324ac2ede5df50ecdf5