### PR TITLE
Add BLE message queue and disconnect alert

### DIFF
--- a/app/routes/Home.tsx
+++ b/app/routes/Home.tsx
@@ -25,6 +25,8 @@ export default function Home() {
     pauseRssi,
     resumeRssi,
     isMonitoring,
+    messages,
+    disconnectAlert,
   } = useBle();
   const [refreshing, setRefreshing] = useState(false);
   const theme = useTheme();
@@ -125,6 +127,29 @@ export default function Home() {
               </Text>
             </View>
             <Text style={{ marginTop: 12 }}>Potencia do sinal: {rssi}</Text>
+          </Card.Content>
+        </Card>
+      )}
+
+      {disconnectAlert && (
+        <Card style={[styles.card, { backgroundColor: "#f8d7da" }]}>
+          <Card.Content>
+            <Text style={{ color: "#721c24", fontWeight: "bold" }}>
+              Dispositivo desconectado!
+            </Text>
+          </Card.Content>
+        </Card>
+      )}
+
+      {messages.length > 0 && (
+        <Card style={styles.card}>
+          <Card.Title title="Mensagens recebidas" />
+          <Card.Content>
+            {messages.map((m, i) => (
+              <Text key={i} style={{ marginBottom: 4 }}>
+                {m}
+              </Text>
+            ))}
           </Card.Content>
         </Card>
       )}


### PR DESCRIPTION
## Summary
- show received BLE messages in a queue on the Home screen
- alert and vibrate on BLE disconnect
- monitor BLE notifications in context

## Testing
- `npm test -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_685a204db068832491f393d930fa694c